### PR TITLE
MM-25831 Fix timing issue with cancelPing

### DIFF
--- a/app/screens/select_server/select_server.js
+++ b/app/screens/select_server/select_server.js
@@ -313,10 +313,6 @@ export default class SelectServer extends PureComponent {
             error: null,
         });
 
-        const serverUrl = await this.getUrl(url, !retryWithHttp);
-        Client4.setUrl(serverUrl);
-        handleServerUrlChanged(serverUrl);
-
         let cancel = false;
         this.cancelPing = () => {
             cancel = true;
@@ -328,6 +324,10 @@ export default class SelectServer extends PureComponent {
 
             this.cancelPing = null;
         };
+
+        const serverUrl = await this.getUrl(url, !retryWithHttp);
+        Client4.setUrl(serverUrl);
+        handleServerUrlChanged(serverUrl);
 
         try {
             const result = await getPing();


### PR DESCRIPTION
With `getUrl` recently [becoming async](https://github.com/mattermost/mattermost-mobile/commit/293470ff#diff-60b06b1c4aab028b96d9b207e84000c6R316), the global definition of the cancelPing function wasn't being made available in time for use by other functions (e.g. `handleSslProblem` and `handleConnect`)

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) --> 

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs (for both iOS and Android if possible).
-->